### PR TITLE
add support for interpolated event names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ Nanigans.prototype.track = function(track) {
     var event = events[j];
     var params = {
       appId: data.app_id,
-      name: event.name,
+      name: renderByProxy(event.name, track),
       type: event.type,
       userId: data.user_id,
       ut1: data.ut1,
@@ -184,4 +184,17 @@ function get(events, name) {
 function email(user) {
   var identify = new Identify({ userId: user.id(), traits: user.traits() });
   return identify.email();
+}
+
+/**
+ * Render Nanigans event name from template.
+ *
+ * @param {Object} user
+ * @return {String}
+ */
+
+function renderByProxy(template, facade) {
+  return template.replace(/\{\{\ *(\w+?[\.\w+]*?)\ *\}\}/g, function(_, $1) {
+    return facade.proxy($1) || '';
+  });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,13 @@ describe('Nanigans', function() {
           type: 'purchase',
           name: 'main'
         }
+      },
+      {
+        key: 'Watched Game',
+        value: {
+          type: 'visit',
+          name: 'Watched {{ properties.league }} {{ properties.sport }} Game'
+        }
       }
     ]
   };
@@ -96,6 +103,13 @@ describe('Nanigans', function() {
         analytics.user().traits({ email: 'email@example.com' });
         analytics.track('testEvent1');
         analytics.loaded('<img src="http://api.nanigans.com/event.php?app_id=123&type=user&name=invite&user_id=id&ut1=2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3">');
+      });
+
+      it('should interpolate mapped event name template strings', function() {
+        analytics.user().id('id');
+        analytics.user().traits({ email: 'email@example.com' });
+        analytics.track('Watched Game', { league: 'NFL', sport: 'Football' });
+        analytics.loaded('<img src="http://api.nanigans.com/event.php?app_id=123&type=visit&name=Watched%20NFL%20Football%20Game&user_id=id&ut1=2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3">');
       });
 
       it('should track multiple events', function() {


### PR DESCRIPTION
This adds experimental support for template interpolation (using the [`facade.proxy()` mechanism](https://github.com/segmentio/facade/blob/master/lib/facade.js#L41-L63) on the mapped event) in the events' `.name` field. We want to see the use case the few customers that need this come up in order to make the case whether this sort of behavior should be baked in (more elegantly) to all client-side `.mapping` implementations by default. The technical implementation is small and the scope is limited only to a single integration (we're not yet documenting this) so I'm comfortable from a debt perspective giving this a shot.

Example:

![image](https://cloudup.com/c0sZtviQdAP+)

```
analytics.track('Watched Game', { sport: "Football", league: "NFL" });
// => nanigans event: "Watched NFL Football Game"
```

@wcjohnson 
