### PR TITLE
Fix params from improper encoding

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+2.2.0 / 2017-03-20
+==================
+
+  * Remove qs dependancy.
+  * Use custom paramString method to generate a querystring.
+
 2.1.0 / 2016-11-09
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ var Identify = require('segmentio-facade').Identify;
 var Track = require('segmentio-facade').Track;
 var integration = require('@segment/analytics.js-integration');
 var normalize = require('to-no-case');
-var qs = require('component-querystring');
 var sha256 = require('js-sha256');
 
 /**
@@ -115,7 +114,7 @@ Nanigans.prototype.track = function(track) {
       params.products.qty = data.qty;
       params.products.value = data.value;
       params.products.sku = data.sku;
-      params.products = qs.stringify(params.products);
+      params.products = paramStringify(params.products);
       params.userId ? this.load('purchase', params) : this.load('purchase_no_user_id', params);
       break;
     case 'user':
@@ -127,7 +126,7 @@ Nanigans.prototype.track = function(track) {
         params.products.qty = data.qty;
         params.products.value = data.value;
         params.products.sku = data.sku;
-        params.products = qs.stringify(params.products);
+        params.products = paramStringify(params.products);
         params.userId ? this.load('add_to_cart', params) : this.load('add_to_cart_no_user_id', params);
         break;
       default:
@@ -200,4 +199,29 @@ function renderByProxy(template, facade) {
   return template.replace(/\{\{\ *(\w+?[\.\w+]*?)\ *\}\}/g, function(_, $1) {
     return facade.proxy($1) || '';
   });
+}
+
+/**
+ * Generate the queryString ourselves to match Nanigans' expectations.
+ *
+ * @param {Object} props
+ * @return {String}
+ */
+
+function paramStringify(props) {
+  var queryString = '';
+  var propTypes = ['qty', 'value', 'sku'];
+
+  // Iterate over each type of property - prevents hardcoding and allows for changes later.
+  for (var i = 0; i < propTypes.length; ++i) {
+    var propArray = props[propTypes[i]];
+    for (var j = 0; j < propArray.length; ++j) {
+      if (propArray[j]) {
+        if (queryString !== '') queryString += '&';
+        queryString += propTypes[i] + '[' + j + ']=' + propArray[j];
+      }
+    }
+  }
+
+  return queryString;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-nanigans#readme",
   "dependencies": {
     "@segment/analytics.js-integration": "^2.1.0",
-    "component-querystring": "^2.0.0",
     "js-sha256": "^0.3.0",
     "segmentio-facade": "^3.0.3",
     "to-no-case": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nanigans",
   "description": "The Nanigans analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -186,7 +186,7 @@ describe('Nanigans', function() {
           }]
         });
 
-        analytics.loaded('<img src="' + encodeURI('http://api.nanigans.com/event.php'
+        analytics.loaded('<img src="' + encodeURI('http://api.nanigans.com/event.php')
           + '?app_id=123'
           + '&type=purchase'
           + '&name=main'
@@ -197,7 +197,7 @@ describe('Nanigans', function() {
           + '&value[0]=9.99'
           + '&value[1]=9.99'
           + '&sku[0]=f9bf17a9'
-          + '&sku[1]=de96f84c') + '">');
+          + '&sku[1]=de96f84c' + '">');
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -150,19 +150,7 @@ describe('Nanigans', function() {
           }]
         });
 
-        analytics.loaded('<img src="' + encodeURI('http://api.nanigans.com/event.php')
-          + '?app_id=123'
-          + '&type=purchase'
-          + '&name=main'
-          + '&user_id=id'
-          + '&ut1=2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3'
-          + '&unique=2f2bfd58'
-          + '&qty[0]=1'
-          + '&qty[1]=1'
-          + '&value[0]=9.99'
-          + '&value[1]=9.99'
-          + '&sku[0]=f9bf17a9'
-          + '&sku[1]=de96f84c' + '">');
+        analytics.loaded('<img src=http://api.nanigans.com/event.php?app_id=123&type=purchase&name=main&user_id=id&ut1=2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3&unique=2f2bfd58&qty[0]=1&qty[1]=1&value[0]=9.99&value[1]=9.99&sku[0]=f9bf17a9&sku[1]=de96f84c>');
       });
 
       it('should send Order Completed if the user does not have an id', function() {
@@ -186,18 +174,7 @@ describe('Nanigans', function() {
           }]
         });
 
-        analytics.loaded('<img src="' + encodeURI('http://api.nanigans.com/event.php')
-          + '?app_id=123'
-          + '&type=purchase'
-          + '&name=main'
-          + '&ut1=2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3'
-          + '&unique=2f2bfd58'
-          + '&qty[0]=1'
-          + '&qty[1]=1'
-          + '&value[0]=9.99'
-          + '&value[1]=9.99'
-          + '&sku[0]=f9bf17a9'
-          + '&sku[1]=de96f84c' + '">');
+        analytics.loaded('<img src=http://api.nanigans.com/event.php?app_id=123&type=purchase&name=main&ut1=2a539d6520266b56c3b0c525b9e6128858baeccb5ee9b694a2906e123c8d6dd3&unique=2f2bfd58&qty[0]=1&qty[1]=1&value[0]=9.99&value[1]=9.99&sku[0]=f9bf17a9&sku[1]=de96f84c>');
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -150,7 +150,7 @@ describe('Nanigans', function() {
           }]
         });
 
-        analytics.loaded('<img src="' + encodeURI('http://api.nanigans.com/event.php'
+        analytics.loaded('<img src="' + encodeURI('http://api.nanigans.com/event.php')
           + '?app_id=123'
           + '&type=purchase'
           + '&name=main'
@@ -162,7 +162,7 @@ describe('Nanigans', function() {
           + '&value[0]=9.99'
           + '&value[1]=9.99'
           + '&sku[0]=f9bf17a9'
-          + '&sku[1]=de96f84c') + '">');
+          + '&sku[1]=de96f84c' + '">');
       });
 
       it('should send Order Completed if the user does not have an id', function() {


### PR DESCRIPTION
CC @ladanazita @hankim813 

This rectifies the issue where Nanigans was receiving parameters incorrectly due to QS calling encodeURIComponent on them. We now use our own function to encode.

This relies on a report from Ladan, as I've been unable to find supporting documentation myself, so having her review would be appreciated. :)

Old behavior example: &sku%5B0%5D
New and desired behavior: &sku[0]